### PR TITLE
Add Frame Encoder with ACES color management and folder queue GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 #test*
 .vscode
+.frame_encoder_settings.yaml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,46 @@
 # OpenImageIO / FFMPEG Daily
 
+## Frame Encoder
+
+A focused tool for encoding **EXR frame sequences** (and other image formats) to video with **ACES color management** and a **folder queue**.
+
+### Features
+
+- EXR-first workflow with support for TIFF, PNG, JPEG, DPX
+- ACES OCIO transforms (Rec.709, sRGB, P3, ACEScg, ACEScct)
+- Queue multiple sequence folders and encode them in batch
+- Simple PySide6 GUI with live preview and drag-and-drop
+- CLI for scripted/batch use
+
+### Quick Start
+
+```bash
+pip install -r requirements.txt
+
+# Set your ACES OCIO config (download from OpenColorIO-Config-ACES)
+export OCIO=/path/to/aces/config.ocio
+
+# Launch the GUI
+python frame_encoder_gui.py
+
+# Or encode from the command line
+./frame_encoder /path/to/exr/sequence1 /path/to/exr/sequence2 -o /output -ct acescg_rec709
+```
+
+### ACES Setup
+
+1. Download an [OpenColorIO-Config-ACES](https://github.com/AcademySoftwareFoundation/OpenColorIO-Config-ACES) release
+2. Point `OCIO` at `config.ocio`, or set the path in the GUI
+3. Choose a transform matching your EXR input colorspace:
+   - **aces_rec709** — ACES2065-1 scene-linear EXR → Rec.709
+   - **acescg_rec709** — ACEScg renders → Rec.709
+   - **acescct_rec709** — ACEScct graded content → Rec.709
+   - **none** — skip color transform
+
+Configuration lives in `frame_encoder_config.yaml` (codecs, transforms, resolution defaults).
+
+---
+
 ## Overview
 Daily is a tool to convert scene-linear openexr images into display-referred quicktime movies. It supports uint16 precision and uses OpenColorIO for colorspace conversions. Common dailies movie features like text comments, frame number overlays, slate frames, and shot number overlays are supported. It also supports resize operations, including cropping, scaling, padding, and masking.
 

--- a/daily
+++ b/daily
@@ -85,7 +85,6 @@ class GenerateDaily():
         self.movie_location = args.output
         texts = args.text
         commandline_ocio_profile = args.color_transform
-        commandline_ocio_profile = args.ocio
         if args.debug:
             print("Setting DEBUG=True!")
             DEBUG = True
@@ -166,9 +165,10 @@ class GenerateDaily():
                 self.globals_config['ocioconfig'] = env_ocio
                 self.ocioconfig = env_ocio
 
-        if not os.path.exists(self.ocioconfig):
-            log.warning("OCIO Config does not exist: \n\t{0}\n\tNo OCIO color transform will be applied".format(
-                self.ocioconfig))
+        if not self.ocioconfig or not os.path.exists(self.ocioconfig):
+            if self.ocioconfig:
+                log.warning("OCIO Config does not exist: \n\t{0}\n\tNo OCIO color transform will be applied".format(
+                    self.ocioconfig))
             self.ocioconfig = None
 
         # Get default ocio transform to use if none is passed by commandline

--- a/frame_encoder
+++ b/frame_encoder
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Frame Encoder CLI — batch-encode frame sequences from a folder queue."""
+
+from __future__ import print_function
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+CONFIG_FILE = os.path.join(DIR_PATH, "frame_encoder_config.yaml")
+DAILY_SCRIPT = os.path.join(DIR_PATH, "daily")
+
+
+def load_config():
+    with open(CONFIG_FILE, "r") as handle:
+        config = yaml.safe_load(handle)
+    ocioconfig = config.get("globals", {}).get("ocioconfig") or ""
+    if not ocioconfig:
+        env_ocio = os.environ.get("OCIO", "")
+        if env_ocio:
+            config["globals"]["ocioconfig"] = env_ocio
+    return config
+
+
+def find_first_image(folder, extensions):
+    if not os.path.isdir(folder):
+        return None
+    files = []
+    for name in sorted(os.listdir(folder)):
+        ext = os.path.splitext(name)[1].lstrip(".").lower()
+        if ext in extensions:
+            files.append(os.path.join(folder, name))
+    return files[0] if files else None
+
+
+def build_config(overrides):
+    with open(CONFIG_FILE, "r") as handle:
+        config = yaml.safe_load(handle)
+    for key, value in overrides.items():
+        if value is not None:
+            config["globals"][key] = value
+    config["globals"]["debug"] = False
+    temp = tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".yaml")
+    yaml.safe_dump(config, temp)
+    temp.close()
+    return temp.name
+
+
+def encode_folder(folder, args, config):
+    extensions = config.get("globals", {}).get(
+        "input_image_formats", ["exr", "tif", "tiff", "png", "jpg", "jpeg"]
+    )
+    input_file = find_first_image(folder, extensions)
+    if not input_file:
+        print(f"SKIP: no image sequence in {folder}", file=sys.stderr)
+        return 1
+
+    overrides = {
+        "width": args.width,
+        "height": args.height,
+        "framerate": args.framerate,
+        "fit": args.fit,
+    }
+    if args.ocio:
+        overrides["ocioconfig"] = args.ocio
+
+    temp_config = build_config(overrides)
+    cmd = [
+        sys.executable,
+        DAILY_SCRIPT,
+        input_file,
+        "-c",
+        args.codec,
+        "-p",
+        "encode",
+        "-ct",
+        args.color_transform,
+        "-o",
+        args.output,
+    ]
+
+    env = os.environ.copy()
+    env["DAILIES_CONFIG"] = temp_config
+    if args.ocio:
+        env["OCIO"] = args.ocio
+
+    print(f"Encoding: {folder}")
+    result = subprocess.run(cmd, env=env)
+    os.unlink(temp_config)
+    return result.returncode
+
+
+def main():
+    config = load_config()
+    codecs = list(config.get("output_codecs", {}).keys())
+    profiles = list(config.get("ocio_profiles", {}).keys())
+    default_codec = config.get("globals", {}).get("output_codec", "hevc_hq")
+    default_color = config.get("globals", {}).get("ocio_default_transform", "aces_rec709")
+
+    parser = argparse.ArgumentParser(
+        description="Encode frame sequences (mainly EXR) to video with ACES color management."
+    )
+    parser.add_argument(
+        "folders",
+        nargs="+",
+        help="One or more folders containing frame sequences",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=config.get("globals", {}).get("movie_location", "../output"),
+        help="Output directory for encoded movies",
+    )
+    parser.add_argument(
+        "-c",
+        "--codec",
+        default=default_codec,
+        choices=codecs,
+        help=f"Output codec (default: {default_codec})",
+    )
+    parser.add_argument(
+        "-ct",
+        "--color-transform",
+        default=default_color,
+        choices=profiles,
+        dest="color_transform",
+        help=f"ACES/OCIO transform (default: {default_color})",
+    )
+    parser.add_argument(
+        "--ocio",
+        default=config.get("globals", {}).get("ocioconfig") or os.environ.get("OCIO"),
+        help="Path to ACES OCIO config.ocio",
+    )
+    parser.add_argument("--width", type=int, default=config.get("globals", {}).get("width", 1920))
+    parser.add_argument("--height", type=int, default=config.get("globals", {}).get("height", 1080))
+    parser.add_argument(
+        "--framerate",
+        type=float,
+        default=float(config.get("globals", {}).get("framerate", 24)),
+    )
+    parser.add_argument("--fit", action="store_true", default=config.get("globals", {}).get("fit", True))
+    parser.add_argument("--no-fit", action="store_false", dest="fit")
+
+    args = parser.parse_args()
+
+    if args.color_transform != "none" and not args.ocio:
+        print("Error: --ocio or $OCIO required for color transforms", file=sys.stderr)
+        return 1
+    if args.color_transform != "none" and not os.path.isfile(args.ocio):
+        print(f"Error: OCIO config not found: {args.ocio}", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for folder in args.folders:
+        folder = os.path.normpath(folder)
+        if not os.path.isdir(folder):
+            print(f"SKIP: not a directory: {folder}", file=sys.stderr)
+            failures += 1
+            continue
+        code = encode_folder(folder, args, config)
+        if code != 0:
+            failures += 1
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/frame_encoder_config.yaml
+++ b/frame_encoder_config.yaml
@@ -1,0 +1,219 @@
+# Frame Encoder configuration
+# Encode EXR (and other) image sequences to video with ACES color management.
+
+globals:
+  # ACES OCIO config — set OCIO env var or edit this path.
+  # Download: https://github.com/AcademySoftwareFoundation/OpenColorIO-Config-ACES
+  ocioconfig:
+  ocio_default_transform: aces_rec709
+
+  debug: false
+  cropwidth:
+  cropheight:
+  width: 1920
+  height: 1080
+  fit: true
+  filter:
+  framerate: 24
+  vf:
+  output_codec: hevc_hq
+  movie_location: ../output
+  movie_ext: mov
+  movie_append_codec: true
+  input_image_formats: ['exr', 'tif', 'tiff', 'png', 'jpg', 'jpeg', 'dpx']
+
+###############################################
+# ACES color transforms (OpenColorIO)
+# Requires an ACES OCIO config (ACES 1.2+ / 2.x).
+# Input colorspace is the first value; output display is the second.
+###############################################
+
+ocio_profiles:
+  none:
+    ociocolorconvert:
+
+  # Scene-linear ACES2065-1 (common EXR default) to display spaces
+  aces_rec709:
+    ociocolorconvert: ["ACES2065-1", "Output - Rec.709"]
+  aces_srgb:
+    ociocolorconvert: ["ACES2065-1", "Output - sRGB"]
+  aces_p3:
+    ociocolorconvert: ["ACES2065-1", "Output - P3-D65 ST2084 (PQ)"]
+
+  # ACEScg working space (typical CG/VFX renders)
+  acescg_rec709:
+    ociocolorconvert: ["ACEScg", "Output - Rec.709"]
+  acescg_srgb:
+    ociocolorconvert: ["ACEScg", "Output - sRGB"]
+
+  # ACEScct log grading space
+  acescct_rec709:
+    ociocolorconvert: ["ACEScct", "Output - Rec.709"]
+
+  # Raw linear (no ACES IDT) — use when EXR is already display-referred
+  linear_rec709:
+    ociocolorconvert: ["Utility - Linear - sRGB", "Output - Rec.709"]
+
+###############################################
+# Minimal encode profile — no overlays
+###############################################
+
+dailies_profiles:
+  encode:
+    text_elements:
+
+###############################################
+# Output codecs
+###############################################
+
+output_codecs:
+  hevc_hq:
+    name: hevc_hq
+    overlay: encode
+    cropwidth:
+    cropheight:
+    width: 1920
+    height: 1080
+    fit:
+    framerate:
+    codec: libx265
+    profile: main444-10-intra
+    qscale:
+    preset: medium
+    keyint: 1
+    bframes: 0
+    tune: psnr
+    crf: 13
+    pix_fmt: yuv444p10le
+    vf: colormatrix=bt601:bt709
+    bitdepth: 10
+    vendor:
+    metadata_s:
+    bitrate:
+    movie_ext: mov
+
+  hevc_lq:
+    name: hevc_lq
+    overlay: encode
+    cropwidth:
+    cropheight:
+    width: 1920
+    height: 1080
+    fit:
+    framerate:
+    codec: libx265
+    profile: main10-intra
+    qscale:
+    preset: medium
+    keyint: 1
+    bframes: 0
+    tune: psnr
+    crf: 17
+    pix_fmt: yuv420p10le
+    vf: colormatrix=bt601:bt709
+    bitdepth: 10
+    vendor:
+    metadata_s:
+    bitrate:
+    movie_ext: mov
+
+  prores_422hq:
+    name: prores_422hq
+    overlay: encode
+    cropwidth:
+    cropheight:
+    width:
+    height:
+    fit:
+    framerate:
+    codec: prores_ks
+    profile: 3
+    qscale: 7
+    preset:
+    keyint:
+    bframes:
+    tune:
+    crf:
+    pix_fmt: yuva444p10le
+    vf: colormatrix=bt601:bt709
+    bitdepth: 10
+    vendor: ap10
+    metadata_s: encoder="Apple ProRes 422 HQ"
+    bitrate:
+    movie_ext: mov
+
+  prores_4444:
+    name: prores_4444
+    overlay: encode
+    cropwidth:
+    cropheight:
+    width:
+    height:
+    fit:
+    framerate:
+    codec: prores_ks
+    profile: 4
+    qscale: 5
+    preset:
+    keyint:
+    bframes:
+    tune:
+    crf:
+    pix_fmt: yuva444p10le
+    vf: colormatrix=bt601:bt709
+    bitdepth: 10
+    vendor: ap10
+    metadata_s: encoder="Apple ProRes 4444"
+    bitrate:
+    movie_ext: mov
+
+  avchq:
+    name: avchq
+    overlay: encode
+    cropwidth:
+    cropheight:
+    width: 1920
+    height: 1080
+    fit:
+    framerate:
+    codec: libx264
+    profile: high444
+    qscale:
+    preset: slower
+    keyint: 1
+    bframes: 0
+    tune: film
+    crf: 13
+    pix_fmt: yuv444p10le
+    vf: colormatrix=bt601:bt709
+    bitdepth: 10
+    vendor:
+    metadata_s:
+    bitrate:
+    movie_ext: mov
+
+  mjpeg:
+    name: mjpeg
+    overlay: encode
+    cropwidth:
+    cropheight:
+    width: 1920
+    height: 1080
+    fit:
+    framerate:
+    codec: copy
+    profile:
+    quality: 90
+    qscale:
+    preset:
+    keyint:
+    bframes:
+    tune:
+    crf:
+    pix_fmt:
+    vf:
+    bitdepth: 8
+    vendor:
+    metadata_s:
+    bitrate:
+    movie_ext: mov

--- a/frame_encoder_gui.py
+++ b/frame_encoder_gui.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""Frame Encoder GUI — queue EXR frame sequences for video encoding with ACES."""
+
+import os
+import re
+import sys
+import yaml
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+CONFIG_FILE = os.path.join(DIR_PATH, "frame_encoder_config.yaml")
+DAILY_SCRIPT = os.path.join(DIR_PATH, "daily")
+SETTINGS_FILE = os.path.join(DIR_PATH, ".frame_encoder_settings.yaml")
+
+
+class JobStatus(Enum):
+    PENDING = "Pending"
+    PROCESSING = "Processing"
+    DONE = "Done"
+    ERROR = "Error"
+    SKIPPED = "Skipped"
+
+
+@dataclass
+class QueueJob:
+    folder: str
+    status: JobStatus = JobStatus.PENDING
+    message: str = ""
+
+    def display_name(self) -> str:
+        return os.path.basename(os.path.normpath(self.folder)) or self.folder
+
+
+class EncodeThread(QtCore.QThread):
+    progress = QtCore.Signal(int, int, str)
+    finished = QtCore.Signal(int, str, str)
+    started = QtCore.Signal()
+
+    def __init__(self, args, env, parent=None):
+        super().__init__(parent)
+        self.args = args
+        self.env = env
+        self._temp_config: Optional[str] = None
+
+    def run(self):
+        progress_re = re.compile(r"^PROGRESS (\d+) (\d+)(?: (.*))?$")
+        try:
+            self.started.emit()
+            process = subprocess.Popen(
+                self.args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=self.env,
+                text=True,
+                bufsize=1,
+            )
+
+            while True:
+                line = process.stderr.readline()
+                if not line and process.poll() is not None:
+                    break
+                if not line:
+                    QtCore.QThread.msleep(10)
+                    continue
+
+                line = line.strip()
+                if not line:
+                    continue
+
+                match = progress_re.match(line)
+                if match:
+                    try:
+                        frame = int(match.group(1))
+                        total = int(match.group(2))
+                        img_data = match.group(3) or ""
+                        self.progress.emit(frame, total, img_data)
+                    except (ValueError, IndexError):
+                        continue
+
+            stdout, stderr = process.communicate()
+            self.finished.emit(process.returncode, stdout or "", stderr or "")
+        except Exception as exc:
+            self.finished.emit(-1, "", f"Thread error: {exc}")
+
+    def set_temp_config(self, path: str):
+        self._temp_config = path
+
+    def cleanup(self):
+        if self._temp_config and os.path.isfile(self._temp_config):
+            try:
+                os.unlink(self._temp_config)
+            except OSError:
+                pass
+
+
+class FrameEncoderGUI(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Frame Encoder")
+        self.config = self.load_config()
+        self.encode_thread: Optional[EncodeThread] = None
+        self.queue: list[QueueJob] = []
+        self.current_job_index = -1
+        self.input_dimensions: Optional[tuple[int, int]] = None
+        self.saved_settings = self.load_settings()
+        self.init_ui()
+        self.apply_saved_settings()
+
+    def load_config(self) -> dict:
+        if not os.path.isfile(CONFIG_FILE):
+            QMessageBox.critical(self, "Error", f"Config not found:\n{CONFIG_FILE}")
+            sys.exit(1)
+        with open(CONFIG_FILE, "r") as handle:
+            config = yaml.safe_load(handle)
+        ocioconfig = config.get("globals", {}).get("ocioconfig") or ""
+        if not ocioconfig:
+            env_ocio = os.environ.get("OCIO", "")
+            if env_ocio:
+                config["globals"]["ocioconfig"] = env_ocio
+        return config
+
+    def load_settings(self) -> dict:
+        if os.path.isfile(SETTINGS_FILE):
+            try:
+                with open(SETTINGS_FILE, "r") as handle:
+                    return yaml.safe_load(handle) or {}
+            except Exception:
+                pass
+        return {}
+
+    def save_settings(self):
+        data = {
+            "output_folder": self.out_folder_edit.text(),
+            "codec": self.codec_combo.currentText(),
+            "color_transform": self.color_combo.currentText(),
+            "framerate": self.fps_spin.value(),
+            "width": self.out_width.value(),
+            "height": self.out_height.value(),
+            "fit": self.scale_fit_chk.isChecked(),
+            "ocio_config": self.ocio_edit.text(),
+        }
+        try:
+            with open(SETTINGS_FILE, "w") as handle:
+                yaml.safe_dump(data, handle)
+        except OSError:
+            pass
+
+    def apply_saved_settings(self):
+        if self.saved_settings.get("output_folder"):
+            self.out_folder_edit.setText(self.saved_settings["output_folder"])
+        if self.saved_settings.get("codec"):
+            idx = self.codec_combo.findText(self.saved_settings["codec"])
+            if idx >= 0:
+                self.codec_combo.setCurrentIndex(idx)
+        if self.saved_settings.get("color_transform"):
+            idx = self.color_combo.findText(self.saved_settings["color_transform"])
+            if idx >= 0:
+                self.color_combo.setCurrentIndex(idx)
+        if self.saved_settings.get("framerate"):
+            self.fps_spin.setValue(self.saved_settings["framerate"])
+        if self.saved_settings.get("width"):
+            self.out_width.setValue(self.saved_settings["width"])
+        if self.saved_settings.get("height"):
+            self.out_height.setValue(self.saved_settings["height"])
+        if "fit" in self.saved_settings:
+            self.scale_fit_chk.setChecked(bool(self.saved_settings["fit"]))
+        if self.saved_settings.get("ocio_config"):
+            self.ocio_edit.setText(self.saved_settings["ocio_config"])
+
+    def init_ui(self):
+        central = QtWidgets.QWidget()
+        self.setCentralWidget(central)
+        layout = QtWidgets.QVBoxLayout(central)
+
+        # --- Queue panel ---
+        queue_group = QtWidgets.QGroupBox("Encode Queue")
+        queue_layout = QtWidgets.QVBoxLayout(queue_group)
+
+        self.queue_list = QtWidgets.QListWidget()
+        self.queue_list.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.queue_list.setMinimumHeight(140)
+        queue_layout.addWidget(self.queue_list)
+
+        queue_btn_row = QtWidgets.QHBoxLayout()
+        add_btn = QtWidgets.QPushButton("Add Folder")
+        add_btn.clicked.connect(self.add_folders)
+        remove_btn = QtWidgets.QPushButton("Remove")
+        remove_btn.clicked.connect(self.remove_selected)
+        clear_btn = QtWidgets.QPushButton("Clear")
+        clear_btn.clicked.connect(self.clear_queue)
+        queue_btn_row.addWidget(add_btn)
+        queue_btn_row.addWidget(remove_btn)
+        queue_btn_row.addWidget(clear_btn)
+        queue_btn_row.addStretch()
+        queue_layout.addLayout(queue_btn_row)
+        layout.addWidget(queue_group)
+
+        # --- Settings panel ---
+        settings_group = QtWidgets.QGroupBox("Encode Settings")
+        form = QtWidgets.QFormLayout(settings_group)
+
+        out_row = QtWidgets.QHBoxLayout()
+        self.out_folder_edit = QtWidgets.QLineEdit(
+            self.config.get("globals", {}).get("movie_location", "../output")
+        )
+        out_browse = QtWidgets.QPushButton("Browse")
+        out_browse.clicked.connect(self.select_output_folder)
+        out_row.addWidget(self.out_folder_edit)
+        out_row.addWidget(out_browse)
+        form.addRow("Output Folder:", out_row)
+
+        self.codec_combo = QtWidgets.QComboBox()
+        codecs = list(self.config.get("output_codecs", {}).keys())
+        self.codec_combo.addItems(codecs)
+        default_codec = self.config.get("globals", {}).get("output_codec", "")
+        if default_codec in codecs:
+            self.codec_combo.setCurrentText(default_codec)
+        form.addRow("Codec:", self.codec_combo)
+
+        self.color_combo = QtWidgets.QComboBox()
+        profiles = list(self.config.get("ocio_profiles", {}).keys())
+        self.color_combo.addItems(profiles)
+        default_color = self.config.get("globals", {}).get("ocio_default_transform", "aces_rec709")
+        if default_color in profiles:
+            self.color_combo.setCurrentText(default_color)
+        form.addRow("ACES Transform:", self.color_combo)
+
+        ocio_row = QtWidgets.QHBoxLayout()
+        self.ocio_edit = QtWidgets.QLineEdit(
+            self.config.get("globals", {}).get("ocioconfig", "") or os.environ.get("OCIO", "")
+        )
+        self.ocio_edit.setPlaceholderText("Path to ACES config.ocio (or set $OCIO)")
+        ocio_browse = QtWidgets.QPushButton("Browse")
+        ocio_browse.clicked.connect(self.select_ocio_config)
+        ocio_row.addWidget(self.ocio_edit)
+        ocio_row.addWidget(ocio_browse)
+        form.addRow("OCIO Config:", ocio_row)
+
+        self.fps_spin = QtWidgets.QDoubleSpinBox()
+        self.fps_spin.setRange(1, 120)
+        self.fps_spin.setDecimals(3)
+        self.fps_spin.setValue(float(self.config.get("globals", {}).get("framerate", 24)))
+        form.addRow("Framerate:", self.fps_spin)
+
+        dim_row = QtWidgets.QHBoxLayout()
+        self.out_width = QtWidgets.QSpinBox()
+        self.out_width.setRange(1, 16384)
+        self.out_width.setValue(self.config.get("globals", {}).get("width", 1920))
+        self.out_height = QtWidgets.QSpinBox()
+        self.out_height.setRange(1, 16384)
+        self.out_height.setValue(self.config.get("globals", {}).get("height", 1080))
+        dim_row.addWidget(QtWidgets.QLabel("W:"))
+        dim_row.addWidget(self.out_width)
+        dim_row.addWidget(QtWidgets.QLabel("H:"))
+        dim_row.addWidget(self.out_height)
+        form.addRow("Resolution:", dim_row)
+
+        self.scale_fit_chk = QtWidgets.QCheckBox("Scale to fit (letterbox/pad)")
+        self.scale_fit_chk.setChecked(self.config.get("globals", {}).get("fit", True))
+        form.addRow("", self.scale_fit_chk)
+
+        self.input_dim_label = QtWidgets.QLabel("Input: select a queue folder to inspect")
+        form.addRow("Sequence Info:", self.input_dim_label)
+
+        layout.addWidget(settings_group)
+
+        # --- Progress ---
+        progress_group = QtWidgets.QGroupBox("Progress")
+        progress_layout = QtWidgets.QVBoxLayout(progress_group)
+
+        self.job_label = QtWidgets.QLabel("No job running")
+        self.status_label = QtWidgets.QLabel("Ready")
+        self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setRange(0, 100)
+
+        progress_layout.addWidget(self.job_label)
+        progress_layout.addWidget(self.status_label)
+        progress_layout.addWidget(self.progress_bar)
+        layout.addWidget(progress_group)
+
+        # --- Preview ---
+        self.preview_label = QtWidgets.QLabel("Preview")
+        self.preview_label.setFixedSize(640, 360)
+        self.preview_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.preview_label.setStyleSheet("border: 1px solid #555; background: #1e1e1e; color: #888;")
+        layout.addWidget(self.preview_label, alignment=QtCore.Qt.AlignCenter)
+
+        # --- Actions ---
+        action_row = QtWidgets.QHBoxLayout()
+        self.encode_btn = QtWidgets.QPushButton("Start Queue")
+        self.encode_btn.clicked.connect(self.start_queue)
+        self.stop_btn = QtWidgets.QPushButton("Stop After Current")
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.clicked.connect(self.stop_queue)
+        action_row.addWidget(self.encode_btn)
+        action_row.addWidget(self.stop_btn)
+        layout.addLayout(action_row)
+
+        self.queue_list.currentRowChanged.connect(self.on_queue_selection_changed)
+        self.stop_after_current = False
+
+    def add_folders(self):
+        folder = QFileDialog.getExistingDirectory(self, "Select Frame Sequence Folder")
+        if not folder:
+            return
+        self._add_folder(folder)
+
+    def _add_folder(self, folder: str):
+        folder = os.path.normpath(folder)
+        for job in self.queue:
+            if os.path.normpath(job.folder) == folder:
+                return
+        if not self.find_first_image(folder):
+            QMessageBox.warning(
+                self,
+                "No Sequence",
+                f"No supported image sequence found in:\n{folder}",
+            )
+            return
+        self.queue.append(QueueJob(folder=folder))
+        self.refresh_queue_list()
+
+    def remove_selected(self):
+        rows = sorted({idx.row() for idx in self.queue_list.selectedIndexes()}, reverse=True)
+        for row in rows:
+            if 0 <= row < len(self.queue):
+                del self.queue[row]
+        self.refresh_queue_list()
+
+    def clear_queue(self):
+        if self.encode_thread and self.encode_thread.isRunning():
+            QMessageBox.warning(self, "Busy", "Cannot clear queue while encoding.")
+            return
+        self.queue.clear()
+        self.refresh_queue_list()
+
+    def refresh_queue_list(self):
+        self.queue_list.clear()
+        for job in self.queue:
+            item = QtWidgets.QListWidgetItem(f"[{job.status.value}] {job.display_name()}")
+            if job.message:
+                item.setToolTip(job.message)
+            if job.status == JobStatus.DONE:
+                item.setForeground(QtGui.QColor("#4caf50"))
+            elif job.status == JobStatus.ERROR:
+                item.setForeground(QtGui.QColor("#f44336"))
+            elif job.status == JobStatus.PROCESSING:
+                item.setForeground(QtGui.QColor("#2196f3"))
+            self.queue_list.addItem(item)
+
+    def on_queue_selection_changed(self, row: int):
+        if row < 0 or row >= len(self.queue):
+            return
+        folder = self.queue[row].folder
+        first_image = self.find_first_image(folder)
+        if not first_image:
+            self.input_dim_label.setText("Input: no images found")
+            return
+        dims = self.get_image_dimensions(first_image)
+        if dims:
+            self.input_dimensions = dims
+            self.input_dim_label.setText(f"Input: {dims[0]} x {dims[1]}  ({first_image})")
+        else:
+            self.input_dim_label.setText("Input: could not read dimensions")
+
+    def select_output_folder(self):
+        folder = QFileDialog.getExistingDirectory(self, "Select Output Folder")
+        if folder:
+            self.out_folder_edit.setText(folder)
+
+    def select_ocio_config(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select OCIO Config", "", "OCIO Config (config.ocio);;All Files (*)"
+        )
+        if path:
+            self.ocio_edit.setText(path)
+
+    def find_first_image(self, folder: str) -> Optional[str]:
+        exts = self.config.get("globals", {}).get(
+            "input_image_formats", ["exr", "tif", "tiff", "png", "jpg", "jpeg"]
+        )
+        if not os.path.isdir(folder):
+            return None
+        files = []
+        for name in sorted(os.listdir(folder)):
+            ext = os.path.splitext(name)[1].lstrip(".").lower()
+            if ext in exts:
+                files.append(os.path.join(folder, name))
+        return files[0] if files else None
+
+    def get_image_dimensions(self, image_path: str) -> Optional[tuple[int, int]]:
+        try:
+            import OpenImageIO as oiio
+
+            spec = oiio.ImageBuf(image_path).spec()
+            return spec.width, spec.height
+        except Exception:
+            return None
+
+    def update_preview_image(self, image_data: str):
+        if not image_data:
+            return
+        try:
+            import base64
+
+            img_bytes = base64.b64decode(image_data)
+            pix = QtGui.QPixmap()
+            if pix.loadFromData(img_bytes, "JPEG"):
+                pix = pix.scaled(
+                    self.preview_label.size(),
+                    QtCore.Qt.KeepAspectRatio,
+                    QtCore.Qt.SmoothTransformation,
+                )
+                self.preview_label.setPixmap(pix)
+        except Exception:
+            pass
+
+    def build_temp_config(self) -> str:
+        with open(CONFIG_FILE, "r") as handle:
+            config_copy = yaml.safe_load(handle)
+
+        config_copy["globals"]["width"] = self.out_width.value()
+        config_copy["globals"]["height"] = self.out_height.value()
+        config_copy["globals"]["fit"] = self.scale_fit_chk.isChecked()
+        config_copy["globals"]["framerate"] = self.fps_spin.value()
+        config_copy["globals"]["debug"] = False
+
+        ocio_path = self.ocio_edit.text().strip()
+        if ocio_path:
+            config_copy["globals"]["ocioconfig"] = ocio_path
+
+        temp = tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".yaml")
+        yaml.safe_dump(config_copy, temp)
+        temp.close()
+        return temp.name
+
+    def start_queue(self):
+        if not self.queue:
+            QMessageBox.warning(self, "Empty Queue", "Add at least one folder to the queue.")
+            return
+
+        pending = [j for j in self.queue if j.status in (JobStatus.PENDING, JobStatus.ERROR)]
+        if not pending:
+            for job in self.queue:
+                job.status = JobStatus.PENDING
+                job.message = ""
+            self.refresh_queue_list()
+
+        ocio_path = self.ocio_edit.text().strip()
+        color_transform = self.color_combo.currentText()
+        if color_transform != "none" and not ocio_path:
+            QMessageBox.warning(
+                self,
+                "OCIO Required",
+                "Set an ACES OCIO config path or the $OCIO environment variable "
+                "before encoding with a color transform.",
+            )
+            return
+        if color_transform != "none" and not os.path.isfile(ocio_path):
+            QMessageBox.warning(self, "OCIO Not Found", f"OCIO config not found:\n{ocio_path}")
+            return
+
+        self.save_settings()
+        self.stop_after_current = False
+        self.encode_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        self.process_next_job()
+
+    def stop_queue(self):
+        self.stop_after_current = True
+        self.status_label.setText("Stopping after current job...")
+
+    def process_next_job(self):
+        next_index = -1
+        for idx, job in enumerate(self.queue):
+            if job.status in (JobStatus.PENDING, JobStatus.ERROR):
+                next_index = idx
+                break
+
+        if next_index < 0:
+            self.on_queue_complete()
+            return
+
+        if self.stop_after_current and self.current_job_index >= 0:
+            self.on_queue_complete(stopped=True)
+            return
+
+        self.current_job_index = next_index
+        job = self.queue[next_index]
+        job.status = JobStatus.PROCESSING
+        job.message = ""
+        self.refresh_queue_list()
+        self.queue_list.setCurrentRow(next_index)
+
+        input_file = self.find_first_image(job.folder)
+        if not input_file:
+            job.status = JobStatus.ERROR
+            job.message = "No images found"
+            self.refresh_queue_list()
+            self.process_next_job()
+            return
+
+        temp_config = self.build_temp_config()
+        args = [
+            sys.executable,
+            DAILY_SCRIPT,
+            input_file,
+            "-c",
+            self.codec_combo.currentText(),
+            "-p",
+            "encode",
+            "-ct",
+            self.color_combo.currentText(),
+            "-o",
+            self.out_folder_edit.text().strip(),
+        ]
+
+        env = os.environ.copy()
+        env["DAILIES_CONFIG"] = temp_config
+        ocio_path = self.ocio_edit.text().strip()
+        if ocio_path:
+            env["OCIO"] = ocio_path
+
+        self.job_label.setText(f"Job {next_index + 1}/{len(self.queue)}: {job.display_name()}")
+        self.status_label.setText("Starting encode...")
+        self.progress_bar.setValue(0)
+
+        self.encode_thread = EncodeThread(args, env)
+        self.encode_thread.set_temp_config(temp_config)
+        self.encode_thread.started.connect(self.on_encoding_started)
+        self.encode_thread.progress.connect(self.on_progress)
+        self.encode_thread.finished.connect(self.on_job_finished)
+        self.encode_thread.start()
+
+    @QtCore.Slot()
+    def on_encoding_started(self):
+        self.status_label.setText("Encoding frames...")
+
+    @QtCore.Slot(int, int, str)
+    def on_progress(self, frame: int, total: int, img_data: str):
+        percent = int((frame / total) * 100) if total else 0
+        self.progress_bar.setValue(percent)
+        self.status_label.setText(f"Frame {frame}/{total} ({percent}%)")
+        self.update_preview_image(img_data)
+        QtWidgets.QApplication.processEvents()
+
+    @QtCore.Slot(int, str, str)
+    def on_job_finished(self, retcode: int, stdout: str, stderr: str):
+        job = self.queue[self.current_job_index]
+        if retcode == 0:
+            job.status = JobStatus.DONE
+            job.message = stdout.strip() or "Encode complete"
+        else:
+            job.status = JobStatus.ERROR
+            job.message = stderr.strip() or stdout.strip() or f"Exit code {retcode}"
+
+        self.refresh_queue_list()
+
+        if self.encode_thread:
+            self.encode_thread.cleanup()
+
+        if self.stop_after_current:
+            self.on_queue_complete(stopped=True)
+        else:
+            self.process_next_job()
+
+    def on_queue_complete(self, stopped: bool = False):
+        self.encode_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+        self.stop_after_current = False
+        self.progress_bar.setValue(0)
+
+        done = sum(1 for j in self.queue if j.status == JobStatus.DONE)
+        errors = sum(1 for j in self.queue if j.status == JobStatus.ERROR)
+
+        if stopped:
+            self.status_label.setText("Queue stopped")
+            self.job_label.setText("Stopped")
+        elif errors:
+            self.status_label.setText(f"Finished with {errors} error(s)")
+            self.job_label.setText(f"Complete: {done} succeeded, {errors} failed")
+            QMessageBox.warning(
+                self,
+                "Queue Complete",
+                f"{done} job(s) succeeded, {errors} failed.\nCheck queue tooltips for details.",
+            )
+        else:
+            self.status_label.setText("All jobs complete")
+            self.job_label.setText(f"Complete: {done}/{len(self.queue)}")
+            QMessageBox.information(self, "Queue Complete", f"Successfully encoded {done} sequence(s).")
+
+
+def main():
+    if not os.path.isfile(DAILY_SCRIPT):
+        print(f"Error: encoding backend not found: {DAILY_SCRIPT}", file=sys.stderr)
+        sys.exit(1)
+
+    app = QtWidgets.QApplication(sys.argv)
+    app.setStyle("Fusion")
+    window = FrameEncoderGUI()
+    window.resize(720, 900)
+    window.show()
+
+    # Accept drag-and-drop of folders onto the window
+    def drag_enter(event):
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    def drop_event(event):
+        for url in event.mimeData().urls():
+            path = url.toLocalFile()
+            if os.path.isdir(path):
+                window._add_folder(path)
+        event.acceptProposedAction()
+
+    window.setAcceptDrops(True)
+    window.dragEnterEvent = drag_enter
+    window.dropEvent = drop_event
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+OpenImageIO>=2.0
+numpy
+PyYAML
+Pillow
+PySide6


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Frame Encoder** — a focused tool for encoding EXR frame sequences (and other image formats) to video with ACES color management and batch folder queuing.

### New files

- **`frame_encoder_gui.py`** — PySide6 GUI with:
  - Folder queue (add/remove/clear, drag-and-drop)
  - ACES transform selector and OCIO config path
  - Codec, resolution, framerate settings
  - Live frame preview and per-job progress
  - Sequential batch processing with stop-after-current

- **`frame_encoder`** — CLI for scripted batch encoding of multiple folders

- **`frame_encoder_config.yaml`** — ACES OCIO profiles (`aces_rec709`, `acescg_rec709`, `acescct_rec709`, etc.) and codec presets (HEVC, ProRes, AVC, MJPEG)

- **`requirements.txt`** — Python dependencies

### Backend fixes (`daily`)

- Fixed `--color_transform` being overwritten by `--ocio` (color profile was ignored)
- Fixed `TypeError` when no OCIO config path is set

### Usage

```bash
pip install -r requirements.txt
export OCIO=/path/to/aces/config.ocio
python frame_encoder_gui.py
```

Or CLI:

```bash
./frame_encoder /path/to/exr/seq1 /path/to/exr/seq2 -o /output -ct acescg_rec709
```

Builds on the existing `daily` encoding pipeline (OpenImageIO + ffmpeg) with a minimal overlay profile for clean encodes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e4884ed-b1d1-417d-a1f1-e193ec0822f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e4884ed-b1d1-417d-a1f1-e193ec0822f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

